### PR TITLE
fix: :bug: swap dimensions for portrait devices in image selection and sync

### DIFF
--- a/integration/test_integration.py
+++ b/integration/test_integration.py
@@ -37,7 +37,7 @@ from private_assistant_commons import (
     IntentType,
     create_skill_engine,
 )
-from private_assistant_commons.database import DeviceType, GlobalDevice, Skill
+from private_assistant_commons.database import DeviceType, GlobalDevice, Room, Skill
 from sqlmodel import SQLModel, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -479,3 +479,435 @@ class TestAutomaticRotation:
         assert command_received, "Did not receive DisplayCommand within timeout"
         # The next image (never displayed) should be selected
         assert received_image_id == str(next_image_id), f"Expected image {next_image_id}, got {received_image_id}"
+
+
+@pytest.fixture
+async def room_devices_test_setup(db_engine, skill_config_file, mqtt_config):
+    """Set up multiple devices in a room for testing room-based next picture.
+
+    Creates a room with two online devices and enough images for each device,
+    then starts the skill. Uses a single session to avoid session sharing issues.
+    """
+    async with AsyncSession(db_engine) as session:
+        # Create images (enough for both devices)
+        image_a = Image(
+            id=uuid.uuid4(),
+            source_name="manual",
+            storage_path="manual/image-a.jpg",
+            title="Image A",
+            description="First test image",
+            original_width=1600,
+            original_height=1200,
+            display_duration_seconds=60,
+            created_at=datetime.now() - timedelta(days=2),
+            last_displayed_at=None,
+        )
+        session.add(image_a)
+
+        image_b = Image(
+            id=uuid.uuid4(),
+            source_name="manual",
+            storage_path="manual/image-b.jpg",
+            title="Image B",
+            description="Second test image",
+            original_width=1600,
+            original_height=1200,
+            display_duration_seconds=60,
+            created_at=datetime.now() - timedelta(days=1),
+            last_displayed_at=None,
+        )
+        session.add(image_b)
+
+        # Create DeviceType and Skill
+        device_type = DeviceType(name="picture_display")
+        session.add(device_type)
+
+        skill_record = Skill(name="picture-display-skill-integration-test")
+        session.add(skill_record)
+
+        # Create room
+        room = Room(name="test-room")
+        session.add(room)
+
+        await session.commit()
+        await session.refresh(device_type)
+        await session.refresh(skill_record)
+        await session.refresh(room)
+
+        # Capture IDs before they expire
+        device_type_id = device_type.id
+        skill_record_id = skill_record.id
+        room_id = room.id
+
+        # Create two devices in the same room
+        device_1_id = uuid.uuid4()
+        device_1 = GlobalDevice(
+            id=device_1_id,
+            device_type_id=device_type_id,
+            skill_id=skill_record_id,
+            room_id=room_id,
+            name="inky-room-1",
+            pattern=["inky-room-1", "inky-room-1 display"],
+            device_attributes={
+                "display_width": 1600,
+                "display_height": 1200,
+                "orientation": "landscape",
+                "model": "impression-13.3-spectra6",
+            },
+        )
+        session.add(device_1)
+
+        device_2_id = uuid.uuid4()
+        device_2 = GlobalDevice(
+            id=device_2_id,
+            device_type_id=device_type_id,
+            skill_id=skill_record_id,
+            room_id=room_id,
+            name="inky-room-2",
+            pattern=["inky-room-2", "inky-room-2 display"],
+            device_attributes={
+                "display_width": 1600,
+                "display_height": 1200,
+                "orientation": "landscape",
+                "model": "impression-13.3-spectra6",
+            },
+        )
+        session.add(device_2)
+
+        # Create display states (both online)
+        display_state_1 = DeviceDisplayState(global_device_id=device_1_id, is_online=True)
+        session.add(display_state_1)
+
+        display_state_2 = DeviceDisplayState(global_device_id=device_2_id, is_online=True)
+        session.add(display_state_2)
+
+        await session.commit()
+
+    device_names = ["inky-room-1", "inky-room-2"]
+
+    # Give database time to persist
+    await asyncio.sleep(0.5)
+
+    # Set environment variables
+    os.environ["MQTT_HOST"] = mqtt_config["host"]
+    os.environ["MQTT_PORT"] = str(mqtt_config["port"])
+    os.environ["DEVICE_MQTT_HOST"] = mqtt_config["host"]
+    os.environ["DEVICE_MQTT_PORT"] = str(mqtt_config["port"])
+    os.environ["DEVICE_MQTT_USERNAME"] = ""
+    os.environ["DEVICE_MQTT_PASSWORD"] = ""
+    os.environ["S3_ENDPOINT"] = "localhost:9000"
+    os.environ["S3_BUCKET"] = "inky-images"
+    os.environ["S3_READER_ACCESS_KEY"] = ""
+    os.environ["S3_READER_SECRET_KEY"] = ""
+
+    # Start skill as background task
+    skill_task = asyncio.create_task(start_skill(skill_config_file))
+
+    # Wait for skill to initialize
+    await asyncio.sleep(3)
+
+    yield {"device_names": device_names, "room_name": "test-room"}
+
+    # Cleanup
+    skill_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await skill_task
+
+
+class TestRoomNextPicture:
+    """Test next picture command sends DisplayCommand to all devices in a room."""
+
+    @pytest.mark.asyncio
+    async def test_next_picture_all_room_devices(
+        self,
+        room_devices_test_setup,
+        mqtt_test_client,
+    ):
+        """Test MEDIA_NEXT sends DisplayCommand to every online device in the room.
+
+        Flow:
+        1. Two devices are online in the same room
+        2. Publish IntentRequest with MEDIA_NEXT and room set
+        3. Assert DisplayCommand is published to both device command topics
+        """
+        device_names = room_devices_test_setup["device_names"]
+        room_name = room_devices_test_setup["room_name"]
+
+        # Subscribe to command topics for both devices
+        for name in device_names:
+            await mqtt_test_client.subscribe(f"inky/{name}/command")
+
+        # Build and publish intent request with room
+        classified_intent = ClassifiedIntent(
+            id=uuid.uuid4(),
+            intent_type=IntentType.MEDIA_NEXT,
+            confidence=0.9,
+            entities={},
+            alternative_intents=[],
+            raw_text="next picture",
+            timestamp=datetime.now(),
+        )
+
+        output_topic = f"assistant/test/output/{uuid.uuid4().hex[:8]}"
+        client_request = ClientRequest(
+            id=uuid.uuid4(),
+            text="next picture",
+            room=room_name,
+            output_topic=output_topic,
+        )
+
+        intent_request = IntentRequest(
+            id=uuid.uuid4(),
+            classified_intent=classified_intent,
+            client_request=client_request,
+        )
+
+        intent_json = intent_request.model_dump_json()
+        await mqtt_test_client.publish("assistant/intent_engine/result", intent_json, qos=1)
+
+        # Collect DisplayCommands for each device
+        received_devices: set[str] = set()
+        expected_devices = set(device_names)
+        timeout_seconds = 10
+
+        try:
+            async with asyncio.timeout(timeout_seconds):
+                async for message in mqtt_test_client.messages:
+                    topic = str(message.topic)
+                    payload = message.payload.decode()
+
+                    # Check if this is a device command topic
+                    for name in device_names:
+                        if topic == f"inky/{name}/command":
+                            command_data = json.loads(payload)
+                            assert command_data.get("action") == "display"
+                            assert command_data.get("image_id") is not None
+                            received_devices.add(name)
+                            logger.debug("DisplayCommand received for %s: %s", name, payload)
+
+                    # Stop once all devices received commands
+                    if received_devices == expected_devices:
+                        break
+
+        except TimeoutError:
+            pass
+
+        assert received_devices == expected_devices, (
+            f"Expected commands for {expected_devices}, but only got {received_devices}"
+        )
+
+
+@pytest.fixture
+async def portrait_test_setup(db_engine, skill_config_file, mqtt_config):
+    """Set up a portrait device alongside a landscape device to test orientation-aware selection.
+
+    Creates two devices (portrait + landscape) with matching images for each,
+    then starts the skill. The portrait device should only receive portrait images
+    and the landscape device should only receive landscape images.
+    """
+    async with AsyncSession(db_engine) as session:
+        # Create landscape image (1600x1200)
+        landscape_image = Image(
+            id=uuid.uuid4(),
+            source_name="manual",
+            storage_path="manual/landscape-orient.jpg",
+            title="Landscape Image",
+            description="A landscape-oriented image",
+            original_width=1600,
+            original_height=1200,
+            display_duration_seconds=60,
+            created_at=datetime.now() - timedelta(days=2),
+            last_displayed_at=None,
+        )
+        session.add(landscape_image)
+
+        # Create portrait image (1200x1600 = swapped dimensions)
+        portrait_image = Image(
+            id=uuid.uuid4(),
+            source_name="manual",
+            storage_path="manual/portrait-orient.jpg",
+            title="Portrait Image",
+            description="A portrait-oriented image",
+            original_width=1200,
+            original_height=1600,
+            display_duration_seconds=60,
+            created_at=datetime.now() - timedelta(days=1),
+            last_displayed_at=None,
+        )
+        session.add(portrait_image)
+
+        # Create DeviceType and Skill
+        device_type = DeviceType(name="picture_display")
+        session.add(device_type)
+
+        skill_record = Skill(name="picture-display-skill-integration-test")
+        session.add(skill_record)
+
+        # Create room
+        room = Room(name="orient-room")
+        session.add(room)
+
+        await session.commit()
+        await session.refresh(device_type)
+        await session.refresh(skill_record)
+        await session.refresh(room)
+        await session.refresh(landscape_image)
+        await session.refresh(portrait_image)
+
+        device_type_id = device_type.id
+        skill_record_id = skill_record.id
+        room_id = room.id
+        landscape_image_id = str(landscape_image.id)
+        portrait_image_id = str(portrait_image.id)
+
+        # Landscape device (same panel 1600x1200, orientation=landscape)
+        landscape_device_id = uuid.uuid4()
+        session.add(
+            GlobalDevice(
+                id=landscape_device_id,
+                device_type_id=device_type_id,
+                skill_id=skill_record_id,
+                room_id=room_id,
+                name="inky-landscape",
+                pattern=["inky-landscape"],
+                device_attributes={
+                    "display_width": 1600,
+                    "display_height": 1200,
+                    "orientation": "landscape",
+                    "model": "impression-13.3-spectra6",
+                },
+            )
+        )
+        session.add(DeviceDisplayState(global_device_id=landscape_device_id, is_online=True))
+
+        # Portrait device (same panel 1600x1200 but orientation=portrait)
+        portrait_device_id = uuid.uuid4()
+        session.add(
+            GlobalDevice(
+                id=portrait_device_id,
+                device_type_id=device_type_id,
+                skill_id=skill_record_id,
+                room_id=room_id,
+                name="inky-portrait",
+                pattern=["inky-portrait"],
+                device_attributes={
+                    "display_width": 1600,
+                    "display_height": 1200,
+                    "orientation": "portrait",
+                    "model": "impression-13.3-spectra6",
+                },
+            )
+        )
+        session.add(DeviceDisplayState(global_device_id=portrait_device_id, is_online=True))
+
+        await session.commit()
+
+    await asyncio.sleep(0.5)
+
+    os.environ["MQTT_HOST"] = mqtt_config["host"]
+    os.environ["MQTT_PORT"] = str(mqtt_config["port"])
+    os.environ["DEVICE_MQTT_HOST"] = mqtt_config["host"]
+    os.environ["DEVICE_MQTT_PORT"] = str(mqtt_config["port"])
+    os.environ["DEVICE_MQTT_USERNAME"] = ""
+    os.environ["DEVICE_MQTT_PASSWORD"] = ""
+    os.environ["S3_ENDPOINT"] = "localhost:9000"
+    os.environ["S3_BUCKET"] = "inky-images"
+    os.environ["S3_READER_ACCESS_KEY"] = ""
+    os.environ["S3_READER_SECRET_KEY"] = ""
+
+    skill_task = asyncio.create_task(start_skill(skill_config_file))
+    await asyncio.sleep(3)
+
+    yield {
+        "landscape_image_id": landscape_image_id,
+        "portrait_image_id": portrait_image_id,
+    }
+
+    skill_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await skill_task
+
+
+class TestPortraitOrientation:
+    """Test that portrait and landscape devices receive correctly oriented images."""
+
+    @pytest.mark.asyncio
+    async def test_portrait_device_gets_portrait_image(
+        self,
+        portrait_test_setup,
+        mqtt_test_client,
+    ):
+        """Test MEDIA_NEXT gives each device an image matching its orientation.
+
+        Flow:
+        1. Room has a landscape device and a portrait device
+        2. DB has one landscape image (1600x1200) and one portrait image (1200x1600)
+        3. Publish MEDIA_NEXT for the room
+        4. Assert landscape device gets the landscape image
+        5. Assert portrait device gets the portrait image
+        """
+        landscape_image_id = portrait_test_setup["landscape_image_id"]
+        portrait_image_id = portrait_test_setup["portrait_image_id"]
+
+        await mqtt_test_client.subscribe("inky/inky-landscape/command")
+        await mqtt_test_client.subscribe("inky/inky-portrait/command")
+
+        classified_intent = ClassifiedIntent(
+            id=uuid.uuid4(),
+            intent_type=IntentType.MEDIA_NEXT,
+            confidence=0.9,
+            entities={},
+            alternative_intents=[],
+            raw_text="next picture",
+            timestamp=datetime.now(),
+        )
+
+        output_topic = f"assistant/test/output/{uuid.uuid4().hex[:8]}"
+        client_request = ClientRequest(
+            id=uuid.uuid4(),
+            text="next picture",
+            room="orient-room",
+            output_topic=output_topic,
+        )
+
+        intent_request = IntentRequest(
+            id=uuid.uuid4(),
+            classified_intent=classified_intent,
+            client_request=client_request,
+        )
+
+        await mqtt_test_client.publish("assistant/intent_engine/result", intent_request.model_dump_json(), qos=1)
+
+        received: dict[str, str] = {}
+        timeout_seconds = 10
+
+        try:
+            async with asyncio.timeout(timeout_seconds):
+                async for message in mqtt_test_client.messages:
+                    topic = str(message.topic)
+                    payload = message.payload.decode()
+
+                    if topic == "inky/inky-landscape/command":
+                        command_data = json.loads(payload)
+                        assert command_data.get("action") == "display"
+                        received["landscape"] = command_data["image_id"]
+                    elif topic == "inky/inky-portrait/command":
+                        command_data = json.loads(payload)
+                        assert command_data.get("action") == "display"
+                        received["portrait"] = command_data["image_id"]
+
+                    if "landscape" in received and "portrait" in received:
+                        break
+
+        except TimeoutError:
+            pass
+
+        assert "landscape" in received, "Landscape device did not receive a command"
+        assert "portrait" in received, "Portrait device did not receive a command"
+
+        assert received["landscape"] == landscape_image_id, (
+            f"Landscape device got image {received['landscape']}, expected {landscape_image_id}"
+        )
+        assert received["portrait"] == portrait_image_id, (
+            f"Portrait device got image {received['portrait']}, expected {portrait_image_id}"
+        )

--- a/src/private_assistant_picture_display_skill/immich/sync_service.py
+++ b/src/private_assistant_picture_display_skill/immich/sync_service.py
@@ -399,6 +399,10 @@ class ImmichSyncService:
                 f"Got: width={width}, height={height}, orientation={orientation}"
             )
 
+        # Portrait devices have the panel physically rotated, so swap dimensions
+        if orientation == "portrait":
+            width, height = height, width
+
         return DeviceRequirements(
             width=width,
             height=height,

--- a/src/private_assistant_picture_display_skill/services/image_manager.py
+++ b/src/private_assistant_picture_display_skill/services/image_manager.py
@@ -64,11 +64,16 @@ class ImageManager:
         attrs = device.device_attributes or {}
         display_width = attrs.get("display_width")
         display_height = attrs.get("display_height")
+        orientation = attrs.get("orientation", "landscape")
 
         # Device must have both dimensions set
         if display_width is None or display_height is None:
             self.logger.warning("Device %s missing display dimensions, skipping", device.name)
             return None
+
+        # Portrait devices need swapped dimensions (panel is physically rotated)
+        if orientation == "portrait":
+            display_width, display_height = display_height, display_width
 
         async with AsyncSession(self.engine) as session:
             # Build query - require exact dimension match

--- a/tests/test_image_manager.py
+++ b/tests/test_image_manager.py
@@ -1,0 +1,137 @@
+"""Tests for ImageManager image selection logic."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from private_assistant_commons.database import GlobalDevice
+
+from private_assistant_picture_display_skill.models.image import Image
+from private_assistant_picture_display_skill.services.image_manager import ImageManager
+
+
+def _make_device(orientation: str = "landscape", attrs: dict | None = None) -> MagicMock:
+    """Create a mock GlobalDevice with given orientation."""
+    device = MagicMock(spec=GlobalDevice)
+    device.id = uuid4()
+    device.name = f"test-{orientation}"
+    device.device_attributes = attrs or {
+        "display_width": 1600,
+        "display_height": 1200,
+        "orientation": orientation,
+        "model": "test-model",
+    }
+    return device
+
+
+def _make_image(width: int = 1600, height: int = 1200, title: str = "Test") -> Image:
+    """Create a sample Image."""
+    return Image(
+        id=uuid4(),
+        source_name="manual",
+        storage_path=f"manual/{title.lower()}.jpg",
+        title=title,
+        original_width=width,
+        original_height=height,
+        display_duration_seconds=60,
+        created_at=datetime.now(),
+    )
+
+
+def _create_image_manager() -> ImageManager:
+    """Create ImageManager with mocked dependencies."""
+    device_mqtt = MagicMock()
+    device_mqtt.publish_command = AsyncMock()
+    skill_config = MagicMock()
+    skill_config.default_display_duration = 3600
+    return ImageManager(
+        engine=MagicMock(),
+        device_mqtt=device_mqtt,
+        skill_config=skill_config,
+        logger=MagicMock(),
+    )
+
+
+class TestPortraitImageSelection:
+    """Test that portrait devices receive portrait-dimensioned images."""
+
+    @pytest.mark.asyncio
+    async def test_landscape_device_queries_landscape_dimensions(self):
+        """Landscape device (1600x1200) should query for 1600x1200 images."""
+        manager = _create_image_manager()
+        landscape_image = _make_image(1600, 1200, "Landscape")
+
+        mock_result = MagicMock()
+        mock_result.first.return_value = landscape_image
+        mock_session = AsyncMock()
+        mock_session.exec = AsyncMock(return_value=mock_result)
+
+        with patch("private_assistant_picture_display_skill.services.image_manager.AsyncSession") as mock_session_cls:
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            device = _make_device("landscape")
+            result = await manager.get_next_image_for_device(device)
+
+        assert result is not None
+        assert result.original_width == 1600
+        assert result.original_height == 1200
+
+    @pytest.mark.asyncio
+    async def test_portrait_device_queries_swapped_dimensions(self):
+        """Portrait device (panel 1600x1200) should query for 1200x1600 images."""
+        manager = _create_image_manager()
+        portrait_image = _make_image(1200, 1600, "Portrait")
+
+        mock_result = MagicMock()
+        mock_result.first.return_value = portrait_image
+        mock_session = AsyncMock()
+        mock_session.exec = AsyncMock(return_value=mock_result)
+
+        with patch("private_assistant_picture_display_skill.services.image_manager.AsyncSession") as mock_session_cls:
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            device = _make_device("portrait")
+            result = await manager.get_next_image_for_device(device)
+
+        assert result is not None
+        assert result.original_width == 1200
+        assert result.original_height == 1600
+
+        # Verify the SQL query used swapped dimensions by inspecting the call
+        call_args = mock_session.exec.call_args
+        query = call_args[0][0]
+        # Compile the query and check the parameters contain swapped values
+        compiled = query.compile(compile_kwargs={"literal_binds": True})
+        query_str = str(compiled)
+        # Width should be 1200 (swapped from 1600) and height 1600 (swapped from 1200)
+        assert "1200" in query_str
+        assert "1600" in query_str
+
+    @pytest.mark.asyncio
+    async def test_no_orientation_defaults_to_landscape(self):
+        """Device without orientation attribute should behave as landscape."""
+        manager = _create_image_manager()
+        image = _make_image(1600, 1200)
+
+        mock_result = MagicMock()
+        mock_result.first.return_value = image
+        mock_session = AsyncMock()
+        mock_session.exec = AsyncMock(return_value=mock_result)
+
+        with patch("private_assistant_picture_display_skill.services.image_manager.AsyncSession") as mock_session_cls:
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            device = _make_device(
+                attrs={
+                    "display_width": 1600,
+                    "display_height": 1200,
+                }
+            )
+            result = await manager.get_next_image_for_device(device)
+
+        assert result is not None
+        assert result.original_width == 1600

--- a/tests/test_immich_sync_service.py
+++ b/tests/test_immich_sync_service.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 import pytest
 from minio.error import S3Error
+from private_assistant_commons.database import GlobalDevice
 from pydantic import ValidationError
 
 from private_assistant_picture_display_skill.immich.config import ImmichSyncConfig, S3WriterConfig
@@ -441,3 +442,69 @@ async def test_cleanup_called_before_capacity_check() -> None:
 
     assert call_order[0] == "cleanup"
     assert "count" in call_order
+
+
+class TestGetDeviceRequirementsPortrait:
+    """Test that _get_device_requirements swaps dimensions for portrait devices."""
+
+    @pytest.mark.asyncio
+    async def test_landscape_preserves_dimensions(self) -> None:
+        """Landscape device keeps width=1600, height=1200."""
+        device_id = uuid4()
+        device = MagicMock(spec=GlobalDevice)
+        device.device_attributes = {
+            "display_width": 1600,
+            "display_height": 1200,
+            "orientation": "landscape",
+            "model": "test-model",
+        }
+
+        mock_result = MagicMock()
+        mock_result.first.return_value = device
+        mock_session = AsyncMock()
+        mock_session.exec = AsyncMock(return_value=mock_result)
+
+        engine = MagicMock()
+        service = ImmichSyncService.__new__(ImmichSyncService)
+        service.engine = engine
+        service.logger = MagicMock()
+
+        with patch("private_assistant_picture_display_skill.immich.sync_service.AsyncSession") as mock_session_cls:
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            reqs = await service._get_device_requirements(device_id)
+
+        assert reqs.width == 1600
+        assert reqs.height == 1200
+        assert reqs.orientation == "landscape"
+
+    @pytest.mark.asyncio
+    async def test_portrait_swaps_dimensions(self) -> None:
+        """Portrait device swaps to width=1200, height=1600."""
+        device_id = uuid4()
+        device = MagicMock(spec=GlobalDevice)
+        device.device_attributes = {
+            "display_width": 1600,
+            "display_height": 1200,
+            "orientation": "portrait",
+            "model": "test-model",
+        }
+
+        mock_result = MagicMock()
+        mock_result.first.return_value = device
+        mock_session = AsyncMock()
+        mock_session.exec = AsyncMock(return_value=mock_result)
+
+        engine = MagicMock()
+        service = ImmichSyncService.__new__(ImmichSyncService)
+        service.engine = engine
+        service.logger = MagicMock()
+
+        with patch("private_assistant_picture_display_skill.immich.sync_service.AsyncSession") as mock_session_cls:
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            reqs = await service._get_device_requirements(device_id)
+
+        assert reqs.width == 1200
+        assert reqs.height == 1600
+        assert reqs.orientation == "portrait"

--- a/uv.lock
+++ b/uv.lock
@@ -577,7 +577,7 @@ wheels = [
 
 [[package]]
 name = "private-assistant-picture-display-skill"
-version = "0.9.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "coloraide" },


### PR DESCRIPTION
Portrait devices store raw panel dimensions (1600x1200) in device_attributes but need swapped dimensions (1200x1600) for correct image matching. Both the image manager query and sync service now account for orientation.

Adds unit tests for portrait dimension handling and integration tests for room-based next picture and portrait orientation selection.