### PR TITLE
feat: :sparkles: add vibrancy filter to reject dull/dark images for e-ink

### DIFF
--- a/migrations/002_add_vibrancy_score.sql
+++ b/migrations/002_add_vibrancy_score.sql
@@ -1,0 +1,8 @@
+-- Migration: Add min_vibrancy_score to immich_sync_jobs
+-- Date: 2026-04-11
+
+ALTER TABLE immich_sync_jobs
+    ADD COLUMN IF NOT EXISTS min_vibrancy_score FLOAT DEFAULT 0.2;
+
+COMMENT ON COLUMN immich_sync_jobs.min_vibrancy_score IS
+    'Minimum vibrancy score (0.0-1.0) for e-ink display suitability. 0.0 = disabled.';

--- a/src/private_assistant_picture_display_skill/immich/sync_service.py
+++ b/src/private_assistant_picture_display_skill/immich/sync_service.py
@@ -39,6 +39,7 @@ class ProcessResult(Enum):
     SKIPPED_EXISTING = auto()
     SKIPPED_UNDERSIZED = auto()
     SKIPPED_COLOR_MISMATCH = auto()
+    SKIPPED_LOW_VIBRANCY = auto()
 
 
 @dataclass
@@ -51,6 +52,7 @@ class SyncResult:
     skipped_existing: int = 0
     skipped_undersized: int = 0  # Too small for target dimensions
     skipped_color_mismatch: int = 0  # Color profile incompatible
+    skipped_low_vibrancy: int = 0  # Low saturation and contrast
     stopped_at_limit: bool = False  # True if total image limit was reached
     errors: list[str] = field(default_factory=list)
 
@@ -61,7 +63,8 @@ class SyncResult:
             f"SyncResult(fetched={self.fetched}, filtered={self.filtered}, "
             f"downloaded={self.downloaded}, skipped_existing={self.skipped_existing}, "
             f"skipped_undersized={self.skipped_undersized}, "
-            f"skipped_color={self.skipped_color_mismatch}, errors={len(self.errors)}{limit_info})"
+            f"skipped_color={self.skipped_color_mismatch}, "
+            f"skipped_vibrancy={self.skipped_low_vibrancy}, errors={len(self.errors)}{limit_info})"
         )
 
 
@@ -363,6 +366,8 @@ class ImmichSyncService:
             result.skipped_undersized += 1
         elif process_result == ProcessResult.SKIPPED_COLOR_MISMATCH:
             result.skipped_color_mismatch += 1
+        elif process_result == ProcessResult.SKIPPED_LOW_VIBRANCY:
+            result.skipped_low_vibrancy += 1
 
     async def _get_device_requirements(self, device_id: UUID) -> DeviceRequirements:
         """Get display requirements from global device table.
@@ -457,6 +462,15 @@ class ImmichSyncService:
                     self.logger.info("Skipping asset %s: color score %.2f < %.2f", asset.id, score, min_score)
                     return ProcessResult.SKIPPED_COLOR_MISMATCH
                 self.logger.debug("Asset %s color score: %.2f", asset.id, score)
+
+            # Check vibrancy (saturation/contrast) for e-ink suitability
+            min_vibrancy = job.min_vibrancy_score
+            if min_vibrancy > 0:
+                vibrancy = ColorProfileAnalyzer.calculate_vibrancy_score(image_bytes)
+                if vibrancy < min_vibrancy:
+                    self.logger.info("Skipping asset %s: vibrancy score %.2f < %.2f", asset.id, vibrancy, min_vibrancy)
+                    return ProcessResult.SKIPPED_LOW_VIBRANCY
+                self.logger.debug("Asset %s vibrancy score: %.2f", asset.id, vibrancy)
 
             # Process to target dimensions
             self.logger.debug("Processing image to %dx%d", target_width, target_height)

--- a/src/private_assistant_picture_display_skill/models/immich_sync_job.py
+++ b/src/private_assistant_picture_display_skill/models/immich_sync_job.py
@@ -49,6 +49,7 @@ class ImmichSyncJob(SQLModel, table=True):
         camera_model: Camera model filter
         rating: Minimum rating filter (0-5)
         min_color_score: Minimum color compatibility for Spectra 6 (0.0-1.0)
+        min_vibrancy_score: Minimum vibrancy (saturation/contrast) for e-ink (0.0-1.0)
 
     """
 
@@ -97,12 +98,18 @@ class ImmichSyncJob(SQLModel, table=True):
     taken_before: datetime | None = Field(default=None, description="Photos taken before")
     rating: int | None = Field(default=None, ge=0, le=5, description="Minimum rating")
 
-    # Client-side filter
+    # Client-side filters
     min_color_score: float = Field(
         default=0.5,
         ge=0.0,
         le=1.0,
         description="Minimum color compatibility score for Spectra 6 palette",
+    )
+    min_vibrancy_score: float = Field(
+        default=0.2,
+        ge=0.0,
+        le=1.0,
+        description="Minimum vibrancy score (saturation or contrast) for e-ink suitability",
     )
 
     # Timestamps

--- a/src/private_assistant_picture_display_skill/utils/color_analysis.py
+++ b/src/private_assistant_picture_display_skill/utils/color_analysis.py
@@ -14,6 +14,11 @@ class ColorProfileAnalyzer:
     Uses Delta E (CIE76) for perceptual color distance calculation.
     """
 
+    # Brightness thresholds for saturation analysis (HSV V channel, 0-255)
+    # S is meaningless at V~0 (black) or V~255 (white) — exclude from saturation mean
+    _V_LOW_THRESHOLD: ClassVar[int] = 20
+    _V_HIGH_THRESHOLD: ClassVar[int] = 240
+
     # Spectra 6 palette - measured values from actual display
     # Source: https://forums.pimoroni.com/t/what-rgb-colors-are-you-using-for-the-colors-on-the-impression-spectra-6/27942
     SPECTRA_6_PALETTE: ClassVar[list[Color]] = [
@@ -77,3 +82,53 @@ class ColorProfileAnalyzer:
         # Divide by 50 to normalize (typical "bad" images score ~30-50)
         score = max(0.0, 1.0 - (weighted_distance / 50.0))
         return round(score, 3)
+
+    @classmethod
+    def calculate_vibrancy_score(cls, image_data: bytes) -> float:
+        """Score image vibrancy for e-ink display suitability.
+
+        Combines saturation and contrast into a single score. An image
+        passes if it has EITHER good saturation OR good contrast, so
+        high-contrast B&W photos score well despite zero saturation.
+
+        Algorithm:
+        1. Resize image to 100x100 for speed
+        2. Convert to HSV color space
+        3. Saturation score: mean S of mid-brightness pixels (V 20-240)
+        4. Contrast score: percentile-based dynamic range of V channel
+        5. Return max(saturation, contrast) as vibrancy
+
+        Args:
+            image_data: Image bytes (JPEG, PNG, HEIC, etc.)
+
+        Returns:
+            Vibrancy score 0.0-1.0 (1.0 = highly vibrant or contrasty)
+
+        """
+        with Image.open(BytesIO(image_data)) as img:
+            resized = img.convert("RGB").resize((100, 100))
+            hsv_img = resized.convert("HSV")
+            raw = hsv_img.tobytes()
+
+        # HSV bytes: H, S, V triples for each pixel
+        s_values = [raw[i + 1] for i in range(0, len(raw), 3)]
+        v_values = [raw[i + 2] for i in range(0, len(raw), 3)]
+
+        # Saturation score: mean S of pixels with mid-range brightness
+        # (S is meaningless at V~0 or V~255 — black/white have arbitrary S)
+        mid_brightness_s = [
+            s for s, v in zip(s_values, v_values, strict=True) if cls._V_LOW_THRESHOLD < v < cls._V_HIGH_THRESHOLD
+        ]
+        if len(mid_brightness_s) >= len(s_values) // 10:
+            sat_score = sum(mid_brightness_s) / (len(mid_brightness_s) * 255.0)
+        else:
+            sat_score = 0.0
+
+        # Contrast score: percentile-based dynamic range of V channel
+        v_sorted = sorted(v_values)
+        n = len(v_sorted)
+        p5 = v_sorted[n * 5 // 100]
+        p95 = v_sorted[n * 95 // 100]
+        contrast_score = (p95 - p5) / 255.0
+
+        return round(max(sat_score, contrast_score), 3)

--- a/tests/test_color_analysis.py
+++ b/tests/test_color_analysis.py
@@ -1,0 +1,81 @@
+from io import BytesIO
+
+from PIL import Image
+
+from private_assistant_picture_display_skill.utils.color_analysis import ColorProfileAnalyzer
+
+
+def _image_to_bytes(img: Image.Image) -> bytes:
+    """Save a PIL image to JPEG bytes."""
+    buf = BytesIO()
+    img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+class TestCalculateVibrancyScore:
+    def test_vibrant_color_image_scores_high(self) -> None:
+        """Image with saturated colors should score high via saturation."""
+        img = Image.new("RGB", (200, 200))
+        # Fill with saturated colors: red, green, blue, yellow quadrants
+        for x in range(200):
+            for y in range(200):
+                if x < 100 and y < 100:
+                    img.putpixel((x, y), (255, 0, 0))
+                elif x >= 100 and y < 100:
+                    img.putpixel((x, y), (0, 200, 0))
+                elif x < 100 and y >= 100:
+                    img.putpixel((x, y), (0, 0, 255))
+                else:
+                    img.putpixel((x, y), (255, 255, 0))
+
+        score = ColorProfileAnalyzer.calculate_vibrancy_score(_image_to_bytes(img))
+        assert score > 0.5, f"Vibrant color image should score > 0.5, got {score}"
+
+    def test_high_contrast_bw_image_scores_high(self) -> None:
+        """B&W image with strong contrast should score high via contrast."""
+        img = Image.new("RGB", (200, 200))
+        # Left half black, right half white
+        for x in range(200):
+            for y in range(200):
+                if x < 100:
+                    img.putpixel((x, y), (0, 0, 0))
+                else:
+                    img.putpixel((x, y), (255, 255, 255))
+
+        score = ColorProfileAnalyzer.calculate_vibrancy_score(_image_to_bytes(img))
+        assert score > 0.5, f"High-contrast B&W image should score > 0.5, got {score}"
+
+    def test_uniform_mid_gray_scores_low(self) -> None:
+        """Uniform mid-gray image: no saturation, no contrast -> low score."""
+        img = Image.new("RGB", (200, 200), color=(120, 115, 110))
+
+        score = ColorProfileAnalyzer.calculate_vibrancy_score(_image_to_bytes(img))
+        assert score < 0.15, f"Uniform gray image should score < 0.15, got {score}"
+
+    def test_all_black_image_scores_low(self) -> None:
+        """All-black image has no contrast and no meaningful saturation."""
+        img = Image.new("RGB", (200, 200), color=(0, 0, 0))
+
+        score = ColorProfileAnalyzer.calculate_vibrancy_score(_image_to_bytes(img))
+        assert score < 0.1, f"All-black image should score < 0.1, got {score}"
+
+    def test_dark_but_saturated_image_passes(self) -> None:
+        """Dark but colorful image should pass via saturation."""
+        img = Image.new("RGB", (200, 200))
+        # Dark red and dark blue halves
+        for x in range(200):
+            for y in range(200):
+                if x < 100:
+                    img.putpixel((x, y), (120, 20, 20))
+                else:
+                    img.putpixel((x, y), (20, 20, 120))
+
+        score = ColorProfileAnalyzer.calculate_vibrancy_score(_image_to_bytes(img))
+        assert score > 0.3, f"Dark but saturated image should score > 0.3, got {score}"
+
+    def test_score_in_valid_range(self) -> None:
+        """Score should always be between 0.0 and 1.0."""
+        for color in [(0, 0, 0), (128, 128, 128), (255, 255, 255), (255, 0, 0)]:
+            img = Image.new("RGB", (50, 50), color=color)
+            score = ColorProfileAnalyzer.calculate_vibrancy_score(_image_to_bytes(img))
+            assert 0.0 <= score <= 1.0, f"Score {score} out of range for color {color}"

--- a/tests/test_immich_sync_service.py
+++ b/tests/test_immich_sync_service.py
@@ -1,3 +1,4 @@
+from collections.abc import AsyncIterator
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -10,7 +11,12 @@ from pydantic import ValidationError
 from private_assistant_picture_display_skill.immich.config import DeviceRequirements, ImmichSyncConfig, S3WriterConfig
 from private_assistant_picture_display_skill.immich.models import ImmichAsset, ImmichExifInfo
 from private_assistant_picture_display_skill.immich.storage import S3StorageClient
-from private_assistant_picture_display_skill.immich.sync_service import CleanupResult, ImmichSyncService
+from private_assistant_picture_display_skill.immich.sync_service import (
+    CleanupResult,
+    ImmichSyncService,
+    ProcessResult,
+    SyncResult,
+)
 from private_assistant_picture_display_skill.models.image import Image
 from private_assistant_picture_display_skill.models.immich_sync_job import ImmichSyncJob
 
@@ -633,3 +639,156 @@ class TestFilterAssets:
         ]
         result = service._filter_assets(assets, self._make_job(), self._landscape_reqs())
         assert len(result) == 1  # Uses top-level (landscape) -> passes landscape filter
+
+
+class TestVibrancyFiltering:
+    """Test vibrancy score filtering in _process_asset and result counters."""
+
+    def _make_service(self) -> ImmichSyncService:
+        with patch("private_assistant_picture_display_skill.immich.sync_service.ImmichClient"):
+            service = ImmichSyncService(
+                engine=MagicMock(),
+                logger=MagicMock(),
+                connection_config=MagicMock(),
+                sync_config=ImmichSyncConfig(_env_file=None),
+                s3_config=S3WriterConfig(
+                    endpoint="localhost:9000",
+                    bucket="test",
+                    secure=False,
+                    access_key="k",
+                    secret_key="s",
+                ),
+            )
+        service.storage = MagicMock()
+        service.storage.object_exists.return_value = False
+        return service
+
+    def _make_asset(self) -> ImmichAsset:
+        return ImmichAsset(
+            id="test-asset",
+            type="IMAGE",
+            original_file_name="test.jpg",
+            original_mime_type="image/jpeg",
+            checksum="abc",
+            file_created_at=datetime.now(),
+            width=4000,
+            height=3000,
+        )
+
+    def _make_job(self, min_vibrancy: float = 0.0, min_color: float = 0.0) -> ImmichSyncJob:
+        return ImmichSyncJob(
+            name="test-job",
+            target_device_id=uuid4(),
+            min_vibrancy_score=min_vibrancy,
+            min_color_score=min_color,
+        )
+
+    def _landscape_reqs(self) -> DeviceRequirements:
+        return DeviceRequirements(width=1920, height=1080, orientation="landscape")
+
+    @pytest.mark.asyncio
+    async def test_vibrancy_skip_below_threshold(self) -> None:
+        """Asset with low vibrancy score is skipped."""
+        service = self._make_service()
+        service.immich = MagicMock()
+
+        async def fake_stream() -> AsyncIterator[bytes]:
+            yield b"fake-image-data"
+
+        service.immich.download_original = MagicMock(return_value=fake_stream())
+
+        with (
+            patch.object(service, "_find_existing_image", new_callable=AsyncMock, return_value=None),
+            patch(
+                "private_assistant_picture_display_skill.immich.sync_service.ColorProfileAnalyzer"
+                ".calculate_compatibility_score",
+                return_value=0.8,
+            ),
+            patch(
+                "private_assistant_picture_display_skill.immich.sync_service.ColorProfileAnalyzer"
+                ".calculate_vibrancy_score",
+                return_value=0.1,
+            ),
+        ):
+            result = await service._process_asset(
+                self._make_asset(), self._make_job(min_vibrancy=0.3, min_color=0.5), self._landscape_reqs()
+            )
+
+        assert result == ProcessResult.SKIPPED_LOW_VIBRANCY
+
+    @pytest.mark.asyncio
+    async def test_vibrancy_pass_above_threshold(self) -> None:
+        """Asset with sufficient vibrancy score passes."""
+        service = self._make_service()
+        service.immich = MagicMock()
+
+        async def fake_stream() -> AsyncIterator[bytes]:
+            yield b"fake-image-data"
+
+        service.immich.download_original = MagicMock(return_value=fake_stream())
+
+        with (
+            patch.object(service, "_find_existing_image", new_callable=AsyncMock, return_value=None),
+            patch(
+                "private_assistant_picture_display_skill.immich.sync_service.ColorProfileAnalyzer"
+                ".calculate_compatibility_score",
+                return_value=0.8,
+            ),
+            patch(
+                "private_assistant_picture_display_skill.immich.sync_service.ColorProfileAnalyzer"
+                ".calculate_vibrancy_score",
+                return_value=0.5,
+            ),
+            patch(
+                "private_assistant_picture_display_skill.immich.sync_service.ImageProcessor.process_for_display",
+                return_value=b"processed-image",
+            ),
+            patch.object(service, "_upsert_image_record", new_callable=AsyncMock),
+        ):
+            result = await service._process_asset(
+                self._make_asset(), self._make_job(min_vibrancy=0.3, min_color=0.5), self._landscape_reqs()
+            )
+
+        assert result == ProcessResult.DOWNLOADED
+
+    @pytest.mark.asyncio
+    async def test_vibrancy_disabled_when_zero(self) -> None:
+        """Vibrancy check is skipped when min_vibrancy_score is 0.0."""
+        service = self._make_service()
+        service.immich = MagicMock()
+
+        async def fake_stream() -> AsyncIterator[bytes]:
+            yield b"fake-image-data"
+
+        service.immich.download_original = MagicMock(return_value=fake_stream())
+
+        with (
+            patch.object(service, "_find_existing_image", new_callable=AsyncMock, return_value=None),
+            patch(
+                "private_assistant_picture_display_skill.immich.sync_service.ColorProfileAnalyzer"
+                ".calculate_vibrancy_score",
+            ) as mock_vibrancy,
+            patch(
+                "private_assistant_picture_display_skill.immich.sync_service.ImageProcessor.process_for_display",
+                return_value=b"processed-image",
+            ),
+            patch.object(service, "_upsert_image_record", new_callable=AsyncMock),
+        ):
+            result = await service._process_asset(
+                self._make_asset(), self._make_job(min_vibrancy=0.0, min_color=0.0), self._landscape_reqs()
+            )
+
+        assert result == ProcessResult.DOWNLOADED
+        mock_vibrancy.assert_not_called()
+
+    def test_update_result_counters_vibrancy(self) -> None:
+        """SKIPPED_LOW_VIBRANCY increments the correct counter."""
+        result = SyncResult()
+        ImmichSyncService._update_result_counters(result, ProcessResult.SKIPPED_LOW_VIBRANCY)
+        assert result.skipped_low_vibrancy == 1
+
+    def test_sync_result_str_includes_vibrancy(self) -> None:
+        """SyncResult __str__ includes vibrancy counter."""
+        result = SyncResult(skipped_low_vibrancy=3)
+        text = str(result)
+        assert "skipped_vibrancy=3" in text

--- a/uv.lock
+++ b/uv.lock
@@ -577,7 +577,7 @@ wheels = [
 
 [[package]]
 name = "private-assistant-picture-display-skill"
-version = "0.12.0"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "coloraide" },


### PR DESCRIPTION
Images with low saturation AND low contrast display poorly on Spectra 6 e-ink panels. This adds a vibrancy score (max of saturation, contrast) so high-contrast B&W photos still pass while muddy images are rejected.

Adds min_vibrancy_score to ImmichSyncJob (default 0.2).