### PR TITLE
fix: :bug: use weighted formula for vibrancy score instead of max

### DIFF
--- a/src/private_assistant_picture_display_skill/utils/color_analysis.py
+++ b/src/private_assistant_picture_display_skill/utils/color_analysis.py
@@ -83,20 +83,26 @@ class ColorProfileAnalyzer:
         score = max(0.0, 1.0 - (weighted_distance / 50.0))
         return round(score, 3)
 
+    # Contrast contributes as a secondary signal to vibrancy.
+    # Saturation is the primary indicator of e-ink suitability; contrast
+    # provides a bonus so that images with decent tonal range score slightly
+    # higher, but cannot rescue a desaturated image on its own.
+    _CONTRAST_WEIGHT: ClassVar[float] = 0.3
+
     @classmethod
     def calculate_vibrancy_score(cls, image_data: bytes) -> float:
         """Score image vibrancy for e-ink display suitability.
 
-        Combines saturation and contrast into a single score. An image
-        passes if it has EITHER good saturation OR good contrast, so
-        high-contrast B&W photos score well despite zero saturation.
+        Saturation is the primary signal — desaturated images look muddy on
+        Spectra 6 e-ink regardless of contrast. Contrast acts as a weighted
+        bonus so that saturated images with good tonal range score higher.
 
         Algorithm:
         1. Resize image to 100x100 for speed
         2. Convert to HSV color space
         3. Saturation score: mean S of mid-brightness pixels (V 20-240)
         4. Contrast score: percentile-based dynamic range of V channel
-        5. Return max(saturation, contrast) as vibrancy
+        5. Return sat + 0.3 * contrast (capped at 1.0)
 
         Args:
             image_data: Image bytes (JPEG, PNG, HEIC, etc.)
@@ -131,4 +137,4 @@ class ColorProfileAnalyzer:
         p95 = v_sorted[n * 95 // 100]
         contrast_score = (p95 - p5) / 255.0
 
-        return round(max(sat_score, contrast_score), 3)
+        return round(min(sat_score + cls._CONTRAST_WEIGHT * contrast_score, 1.0), 3)

--- a/tests/test_color_analysis.py
+++ b/tests/test_color_analysis.py
@@ -31,8 +31,8 @@ class TestCalculateVibrancyScore:
         score = ColorProfileAnalyzer.calculate_vibrancy_score(_image_to_bytes(img))
         assert score > 0.5, f"Vibrant color image should score > 0.5, got {score}"
 
-    def test_high_contrast_bw_image_scores_high(self) -> None:
-        """B&W image with strong contrast should score high via contrast."""
+    def test_high_contrast_bw_image_gets_contrast_bonus(self) -> None:
+        """B&W image scores via contrast bonus, but lower than saturated images."""
         img = Image.new("RGB", (200, 200))
         # Left half black, right half white
         for x in range(200):
@@ -43,7 +43,8 @@ class TestCalculateVibrancyScore:
                     img.putpixel((x, y), (255, 255, 255))
 
         score = ColorProfileAnalyzer.calculate_vibrancy_score(_image_to_bytes(img))
-        assert score > 0.5, f"High-contrast B&W image should score > 0.5, got {score}"
+        # Contrast bonus only (~0.3 * 1.0) — no saturation contribution
+        assert 0.2 < score < 0.5, f"B&W image should score 0.2-0.5 via contrast bonus, got {score}"
 
     def test_uniform_mid_gray_scores_low(self) -> None:
         """Uniform mid-gray image: no saturation, no contrast -> low score."""

--- a/uv.lock
+++ b/uv.lock
@@ -577,7 +577,7 @@ wheels = [
 
 [[package]]
 name = "private-assistant-picture-display-skill"
-version = "0.12.1"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "coloraide" },


### PR DESCRIPTION
max(saturation, contrast) let contrast rescue desaturated images since most natural photos have a wide brightness range. Changed to sat + 0.3 * contrast so saturation is the primary signal and contrast only provides a secondary bonus.